### PR TITLE
URL Change and version up

### DIFF
--- a/src/ManaToki/ManaToki.ts
+++ b/src/ManaToki/ManaToki.ts
@@ -12,13 +12,13 @@ import {
 } from "paperback-extensions-common"
 import {parseChapterDetails, parseChapters, parseHomeUpdates, parseHomeList, parseMangaDetails, parseSearch, parseUpdatedMangas} from "./ManaTokiParser"
 
-const MANATOKI_DOMAIN = 'https://manatoki96.net'
+const MANATOKI_DOMAIN = 'https://manatoki97.net'
 const MANATOKI_COMIC = MANATOKI_DOMAIN + '/comic/'
 const method = 'GET'
 
 
 export const ManaTokiInfo: SourceInfo = {
-    version: '1.0.5',
+    version: '1.0.6',
     name: '마나토끼',
     icon: 'icon.png',
     author: 'nar1n',


### PR DESCRIPTION
URL manatoki96.net -> manatoki97.net
Version 1.0.5 -> 1.0.6

* Additional Comment
 The address of the site is changed frequently for some reason.  So I think it would be nice if there was the feature that could be set the address when its address was changed like now